### PR TITLE
根据文档操作时遇到的问题

### DIFF
--- a/cn.zh-CN/ECS 数据迁移至 OSS 教程/准备工作.md
+++ b/cn.zh-CN/ECS 数据迁移至 OSS 教程/准备工作.md
@@ -37,7 +37,8 @@
         ```
         [root@test ~]# vi /etc/exports
         
-        
+        # 如果'mountd'的端口号大于1024，则可能需要加入'insecure':
+        # /data *(rw,no_root_squash,insecure)
         /data *(rw,no_root_squash)
         
         
@@ -127,7 +128,7 @@
 
     2.  防火墙规则中新增开放 `portmapper`、`mountd`、`nfs` 服务的相关端口：tcp 和 udp 协议的 111、20048、2049 三个端口。
 
-        **说明：** 因为 `mountd` 服务使用的是一个随机端口，所以需要先使用 rpcinfo -p localhost 命令查看当前使用的端口之后再配置防火墙。
+        **说明：** 因为 `mountd` 服务使用的是一个随机端口，所以需要先使用 rpcinfo -p localhost 命令查看当前使用的端口之后再配置防火墙。也可以通过更改'/etc/sysconfig/nfs'文件中的'MOUNTD_PORT=xxx'进行端口固定（端口号大于1024时，需要在'/etc/exports'共享文件夹的选项中加入'insecure'）。
 
     3.  依次添加防火墙策略：
 


### PR DESCRIPTION
按照**准备工作**文档操作后，建立迁移数据地址时一直提示**地址异常**，依照后来的解决方法进行文档的更新。

- `mountd`服务不进行端口固定的话，会使用多个端口，开放防火墙和配置安全组会增加复杂度，所以建议将端口固定；
- `mountd`端口号如果大于1024的话，需要在'/etc/exports'的共享文件夹的选项中增加**insecure**。